### PR TITLE
Changing buttons to Previous/Next

### DIFF
--- a/resources/assets/js/components/grid.vue
+++ b/resources/assets/js/components/grid.vue
@@ -29,8 +29,8 @@
               <td :colspan="columns.length">
                   <nav>
                     <ul class="pager">
-                      <li :class="(this.page <= 1) ? 'disabled':''"><a @click.prevent="prevPage" href="#">To the left</a></li>
-                      <li :class="(this.page >= this.pages) ? 'disabled':''"><a @click.prevent="nextPage" href="#">To the right</a></li>
+                      <li :class="(this.page <= 1) ? 'disabled':''"><a @click.prevent="prevPage" href="#">Previous</a></li>
+                      <li :class="(this.page >= this.pages) ? 'disabled':''"><a @click.prevent="nextPage" href="#">Next</a></li>
                     </ul>
                   </nav>
               </td>


### PR DESCRIPTION
The text to scroll the row views are a bit unexpected because I've never seen
a web UI use the terminology "To the left" / "To the right". Changing to
"Previous" / "Next" so that it better matches what most users are familiar
with.